### PR TITLE
Remove duplicate ShadowSoftness from Lighting

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -7,7 +7,6 @@
       "$properties": {
         "GlobalShadows": true,
         "Technology": "ShadowMap",
-        "ShadowSoftness": 0.5,
         "TimeOfDay": "14:00:00",
         "GeographicLatitude": 45,
         "ShadowSoftness": 0,


### PR DESCRIPTION
The `0.5` one didn't do anything because it was defined earlier, so I removed it.